### PR TITLE
Add PluginRepository to the lbjava-examples pom

### DIFF
--- a/lbjava-examples/README.md
+++ b/lbjava-examples/README.md
@@ -12,7 +12,7 @@ Here are a couple of sample classification projects which are using LBJava.
 ## How to run 
 To generate outputs for lbj run: 
 ```
-mvn lbj:generate
+mvn lbjava:generate
 ```
 
 and then you can compile the code: 

--- a/lbjava-examples/pom.xml
+++ b/lbjava-examples/pom.xml
@@ -66,4 +66,19 @@
         </plugins>
     </build>
 
+    <!-- needed for lbj plugin -->
+    <pluginRepositories>
+        <pluginRepository>
+            <id>CogcompSoftware</id>
+            <name>CogcompSoftware</name>
+            <url>http://cogcomp.cs.illinois.edu/m2repo/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
 </project>


### PR DESCRIPTION
The `lbjava-maven-plugin` is not fetched when it is not available in local cache (first run).