### PR TITLE
added interface to set bias and removed bias update

### DIFF
--- a/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/learn/SparseWinnow.java
+++ b/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/learn/SparseWinnow.java
@@ -274,6 +274,7 @@ public class SparseWinnow extends LinearThresholdUnit
   public void setParameters(Parameters p) {
     super.setParameters(p);
     beta = p.beta;
+    bias = p.bias;
   }
 
 
@@ -287,6 +288,7 @@ public class SparseWinnow extends LinearThresholdUnit
     Parameters p =
       new Parameters((LinearThresholdUnit.Parameters) super.getParameters());
     p.beta = beta;
+    p.bias = bias;
     return p;
   }
 
@@ -381,7 +383,8 @@ public class SparseWinnow extends LinearThresholdUnit
                      double base) {
     weightVector.scaledMultiply(exampleFeatures, exampleValues, base,
                                 initialWeight);
-    bias *= base;
+    // do not update bias
+    // bias *= base;
   }
 
 
@@ -445,6 +448,11 @@ public class SparseWinnow extends LinearThresholdUnit
      **/
     public double beta;
 
+    /**
+     * The theta or bias: y(wT dot x + theta) < margin
+     */
+    public double bias;
+
 
     /** Sets all the default values. */
     public Parameters() {
@@ -469,6 +477,7 @@ public class SparseWinnow extends LinearThresholdUnit
     public Parameters(Parameters p) {
       super(p);
       beta = p.beta;
+      bias = p.bias;
     }
 
 


### PR DESCRIPTION
@christos-c @danyaljj Please review this PR.

When I was using `SparseWinnow`, I ran into the problem that the accuracy is always around 50%. The issue is that `SparseWinnow` use a constant 1 as bias(theta) and there is no way to set it by the user.

For winnow update rule: y(wT dot x + theta) < margin. Initially weight vector is inited to all 1s, it's very likely (wT dot x + 1) > 0. When y is either 0 or negative, regardless of making a mistake or not, the winnow is always demoting in this case. This deviates greatly from the essence of the update rule of winnow algorithm.

It's suggested in CS 446 homework 3 handout that setting theta to -n, where n is the number of features and do not update it.

I have tested using the updated winnow algorithm, with 10 iterations producing 99.98% accuracy.