### PR TITLE
Minor change to `equals` function in Feature

### DIFF
--- a/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/classify/Feature.java
+++ b/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/classify/Feature.java
@@ -369,13 +369,9 @@ public abstract class Feature implements Cloneable, Comparable, Serializable
              && f.containingPackage != containingPackage)
          : "Features \"" + f + "\" and \"" + this
            + " have equivalent package strings in different objects.";
-    assert !(f.generatingClassifier.equals(generatingClassifier)
-             && f.generatingClassifier != generatingClassifier)
-         : "Features \"" + f + "\" and \"" + this
-           + " have equivalent classifier name strings in different objects.";
 
     return f.containingPackage == containingPackage
-           && f.generatingClassifier == generatingClassifier;
+           && f.generatingClassifier.equals(generatingClassifier);
   }
 
 

--- a/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/learn/LinearThresholdUnit.java
+++ b/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/learn/LinearThresholdUnit.java
@@ -75,8 +75,7 @@ public abstract class LinearThresholdUnit extends Learner
   /** Default value for {@link #learningRate}. */
   public static final double defaultLearningRate = 0.1;
   /** Default for {@link #weightVector}. */
-  public static final SparseWeightVector defaultWeightVector =
-    new SparseWeightVector();
+  public static final SparseWeightVector defaultWeightVector = new SparseWeightVector();
 
   /**
     * The rate at which weights are updated; default
@@ -111,8 +110,6 @@ public abstract class LinearThresholdUnit extends Learner
   protected double negativeThickness;
   /** The label producing classifier's allowable values. */
   protected String[] allowableValues;
-
-
 
   /**
     * Default constructor.  The learning rate and threshold take default
@@ -251,7 +248,6 @@ public abstract class LinearThresholdUnit extends Learner
     setParameters(p);
   }
 
-
   /**
     * Initializing constructor.  Sets all member variables to their associated
     * settings in the {@link LinearThresholdUnit.Parameters} object.
@@ -273,6 +269,11 @@ public abstract class LinearThresholdUnit extends Learner
     setParameters(p);
   }
 
+  public SparseWeightVector getWeightVector() { return weightVector; }
+
+  public double getBias() { return bias; }
+
+  public String[] getAllowableValues() { return allowableValues; }
 
   /**
     * Sets the values of parameters that control the behavior of this learning
@@ -289,7 +290,6 @@ public abstract class LinearThresholdUnit extends Learner
     positiveThickness = p.thickness + p.positiveThickness;
     negativeThickness = p.thickness + p.negativeThickness;
   }
-
 
   /**
     * Retrieves the parameters that are set in this learner.

--- a/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/learn/SparseNetworkLearner.java
+++ b/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/learn/SparseNetworkLearner.java
@@ -23,7 +23,6 @@ import edu.illinois.cs.cogcomp.lbjava.util.ExceptionlessInputStream;
 import edu.illinois.cs.cogcomp.lbjava.util.ExceptionlessOutputStream;
 import edu.illinois.cs.cogcomp.lbjava.util.OVector;
 
-
 /**
   * A <code>SparseNetworkLearner</code> uses multiple
   * {@link LinearThresholdUnit}s to make a multi-class classification.
@@ -50,34 +49,33 @@ import edu.illinois.cs.cogcomp.lbjava.util.OVector;
  **/
 public class SparseNetworkLearner extends Learner
 {
-  /**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 
 /** Default for {@link #baseLTU}. */
-  public static final LinearThresholdUnit defaultBaseLTU =
-    new SparseAveragedPerceptron();
-
+  public static final LinearThresholdUnit defaultBaseLTU = new SparseAveragedPerceptron();
 
   /**
     * The underlying algorithm used to learn each class separately as a binary
     * classifier; default {@link #defaultBaseLTU}.
    **/
   protected LinearThresholdUnit baseLTU;
+
   /**
     * A collection of the linear threshold units used to learn each label,
     * indexed by the label.
    **/
   protected OVector network;
+
   /** The total number of examples in the training data, or 0 if unknown. */
   protected int numExamples;
+
   /**
     * The total number of distinct features in the training data, or 0 if
     * unknown.
    **/
   protected int numFeatures;
+
   /** Whether or not this learner's labeler produces conjunctive features. */
   protected boolean conjunctiveLabels;
 
@@ -141,6 +139,13 @@ public class SparseNetworkLearner extends Learner
     network = new OVector();
   }
 
+  public int getNumExamples() { return numExamples; }
+
+  public int getNumFeatures() { return numFeatures; }
+
+  public LinearThresholdUnit getBaseLTU() { return baseLTU; }
+
+  public OVector getNetwork() { return network; }
 
   /**
     * Sets the values of parameters that control the behavior of this learning
@@ -654,6 +659,7 @@ public class SparseNetworkLearner extends Learner
     }
 
     out.println("End of SparseNetworkLearner");
+    out.close();
   }
 
 
@@ -674,6 +680,7 @@ public class SparseNetworkLearner extends Learner
       if (ltu == null) out.writeString(null);
       else ltu.write(out);
     }
+    out.close();
   }
 
 
@@ -728,10 +735,8 @@ public class SparseNetworkLearner extends Learner
    **/
   public static class Parameters extends Learner.Parameters
   {
-    /**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
+
 	/**
       * The underlying algorithm used to learn each class separately as a
       * binary classifier; default

--- a/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/learn/SparseWeightVector.java
+++ b/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/learn/SparseWeightVector.java
@@ -46,7 +46,6 @@ public class SparseWeightVector implements Cloneable, Serializable
 	/** The weights in the vector indexed by their {@link Lexicon} key. */
 	protected DVector weights;
 
-
 	/** Simply instantiates {@link #weights}. */
 	public SparseWeightVector() { this(new DVector(defaultCapacity)); }
 
@@ -63,7 +62,6 @@ public class SparseWeightVector implements Cloneable, Serializable
 	 * @param w  A vector of weights.
 	 **/
 	public SparseWeightVector(DVector w) { weights = w; }
-
 
 	/**
 	 * Returns the weight of the given feature.

--- a/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/learn/SupportVectorMachine.java
+++ b/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/learn/SupportVectorMachine.java
@@ -330,6 +330,11 @@ public class SupportVectorMachine extends Learner
     setParameters(p);
   }
 
+  public double[] getWeights() {
+    return weights;
+  }
+
+  public int getNumClasses() { return numClasses; }
 
   /**
     * Sets the values of parameters that control the behavior of this learning


### PR DESCRIPTION
We had some issues in Saul when loading the model: https://github.com/IllinoisCogComp/saul/issues/235 

> After serialization for each instances, we do feature extraction. Then in order to do prediction we need to lookup the features in the `Lexicon`, but our classifier never finds the features in the Lexicon; the culprit is this like in the `equals` function of `Feature`: https://github.com/IllinoisCogComp/lbjava/blob/master/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/classify/Feature.java#L378 
> 
> If you change this line to `f.generatingClassifier.equals(generatingClassifier)`  things would start to work. (note the asserts right before this line). In other words, there are two `generatingClassifier` set in the code which have the same string, but different addresses. 
>
> One of the `generatingClassifier` is internal for `Lexicon` and it is set when [saving the lexicon](https://github.com/IllinoisCogComp/lbjava/blob/master/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/classify/Feature.java#L499) on disk and [reading it back](https://github.com/IllinoisCogComp/lbjava/blob/master/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/classify/Feature.java#L591). 

LBjava compares addresses of `generatingClassifier` to make sure everything (Lexicon and feature generators) are compatible. But in Saul, the feature extractors are already defined in DataModel, while Lexicon is being loaded from file. So this check creates problems for Saul when loading models. On the other hand relaxing this check makes LBJava less safe, although I think this usually shouldn't make any problems.