### PR TITLE
Fix a bug in ArrayParser class

### DIFF
--- a/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/parse/ArrayParser.java
+++ b/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/parse/ArrayParser.java
@@ -50,7 +50,7 @@ public class ArrayParser implements Parser {
     public Object next() {
         if (index >= examples.length)
             return null;
-        return (Object[]) examples[index++];
+        return examples[index++];
     }
 
 


### PR DESCRIPTION
Incorrect cast to `Object[]` causes runtime exception while using `ArrayParser`